### PR TITLE
Fix minor comment typo; add some remedial information.

### DIFF
--- a/SAMD51_InterruptTimer.cpp
+++ b/SAMD51_InterruptTimer.cpp
@@ -14,7 +14,13 @@
 #include "Arduino.h"
 #include "SAMD51_InterruptTimer.h"
 
-#define CPU_HZ 48000000
+// Adafruit M4 code (cores/arduino/startup.c) configures these clock generators:
+// 120MHz - GCLK0
+// 100MHz - GCLK2
+// 48MHz  - GCLK1
+// 12MHz  - GCLK4
+
+#define GCLK1_HZ 48000000
 #define TIMER_PRESCALER_DIV 1024
 
 void (*func1)();
@@ -24,7 +30,7 @@ static inline void TC3_wait_for_sync() {
 }
 
 void TC_Timer::startTimer(unsigned long period, void (*f)()) {
-  // Enable the TC bus clock, use clock generator 0
+  // Enable the TC bus clock, use clock generator 1
   GCLK->PCHCTRL[TC3_GCLK_ID].reg = GCLK_PCHCTRL_GEN_GCLK1_Val |
                                    (1 << GCLK_PCHCTRL_CHEN_Pos);
   while (GCLK->SYNCBUSY.reg > 0);
@@ -124,7 +130,7 @@ void TC_Timer::setPeriod(unsigned long period) {
   TC3->COUNT16.CTRLA.reg |= TC_CTRLA_PRESCALER_DIVN;
   TC3_wait_for_sync();
 
-  int compareValue = (int)(CPU_HZ / (prescaler/((float)period / 1000000))) - 1;
+  int compareValue = (int)(GCLK1_HZ / (prescaler/((float)period / 1000000))) - 1;
 
   // Make sure the count is in a proportional position to where it was
   // to prevent any jitter or disconnect when changing the compare value.


### PR DESCRIPTION
Thank you for this excellent library!  I am enjoying using it in my projects.  I am new to the SAMD hardware, so I am reading through libraries such as this to gain some understanding of the lower-level peripheral management.  I was a little confused by the macro definition CPU_HZ=48000000, because the feature description for the M4 Express says it runs at 120MHz.  Running the example creates a 5Hz signal as promised, so I knew the code was correct.

After doing some research I think I understand the clock handling that is in effect for this code, and this pull request is just a humble suggestion for some comment changes that might help other newcomers like myself.

1) Fix typo in comment; GCLK 1 is used; not GCLK 0.
2) Change macro name (CPU_HZ -> GCLK1_HZ) to better match what it refers to.
3) Add some comments to explain assumptions about device vendor clock setup.
